### PR TITLE
removed 'run'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## installation
 
 `sudo apt-get install advancecomp`
-`npm run install`
+`npm install`
 
 ## live-reload server
 


### PR DESCRIPTION
node package manager throws an error (below) when you add run to your npm install command

`npm ERR! Missing script: "install"
npm ERR! 
npm ERR! Did you mean this?
npm ERR!     npm uninstall # Remove a package
npm ERR! 
npm ERR! To see a list of scripts, run:
npm ERR!   npm run`